### PR TITLE
feat(init): support auto analysis rust project

### DIFF
--- a/.changes/config.toml
+++ b/.changes/config.toml
@@ -1,10 +1,8 @@
 [packages]
-semanifold-resolver = { path = "crates/resolver" }
-semanifold = { path = "crates/semanifold" }
 
 [tags]
-chore = "Chore"
-feat = "New Feature"
-fix = "Bug Fix"
 perf = "Performance Improvement"
+chore = "Chore"
+fix = "Bug Fix"
 refactor = "Refactor"
+feat = "New Feature"

--- a/.changes/config.toml
+++ b/.changes/config.toml
@@ -1,6 +1,6 @@
 [packages]
-semanifold = { path = "crates/semanifold" }
 semanifold-resolver = { path = "crates/resolver" }
+semanifold = { path = "crates/semanifold" }
 
 [tags]
 chore = "Chore"

--- a/.changes/config.toml
+++ b/.changes/config.toml
@@ -1,8 +1,12 @@
-[packages]
+[packages.semanifold-resolver]
+path = "crates/resolver"
+
+[packages.semanifold]
+path = "crates/semanifold"
 
 [tags]
-perf = "Performance Improvement"
 chore = "Chore"
+feat = "New Feature"
 fix = "Bug Fix"
 refactor = "Refactor"
-feat = "New Feature"
+perf = "Performance Improvement"

--- a/.changes/config.toml
+++ b/.changes/config.toml
@@ -1,12 +1,12 @@
-[packages.semanifold-resolver]
-path = "crates/resolver"
-
 [packages.semanifold]
 path = "crates/semanifold"
+
+[packages.semanifold-resolver]
+path = "crates/resolver"
 
 [tags]
 chore = "Chore"
 feat = "New Feature"
 fix = "Bug Fix"
-refactor = "Refactor"
 perf = "Performance Improvement"
+refactor = "Refactor"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,55 @@
+{
+  // 使用 IntelliSense 了解相关属性。
+  // 悬停以查看现有属性的描述。
+  // 欲了解更多信息，请访问: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Debug unit tests in library 'semanifold_resolver'",
+      "cargo": {
+        "args": ["test", "--no-run", "--lib", "--package=semanifold-resolver"],
+        "filter": {
+          "name": "semanifold_resolver",
+          "kind": "lib"
+        }
+      },
+      "args": [],
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Debug executable 'semanifold'",
+      "cargo": {
+        "args": ["build", "--bin=semanifold", "--package=semanifold"],
+        "filter": {
+          "name": "semanifold",
+          "kind": "bin"
+        }
+      },
+      "args": ["init"],
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Debug unit tests in executable 'semanifold'",
+      "cargo": {
+        "args": [
+          "test",
+          "--no-run",
+          "--bin=semanifold",
+          "--package=semanifold"
+        ],
+        "filter": {
+          "name": "semanifold",
+          "kind": "bin"
+        }
+      },
+      "args": [],
+      "cwd": "${workspaceFolder}"
+    }
+  ]
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,6 +229,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -463,6 +469,7 @@ dependencies = [
  "clap",
  "colored",
  "fern",
+ "glob",
  "inquire",
  "log",
  "saphyr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,6 +483,7 @@ name = "semanifold-resolver"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "glob",
  "log",
  "saphyr",
  "semver",

--- a/crates/resolver/Cargo.toml
+++ b/crates/resolver/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 anyhow = "1.0.99"
+glob = "0.3.3"
 log = "0.4.27"
 saphyr = "0.0.6"
 semver = "1.0.26"

--- a/crates/resolver/src/analyzer.rs
+++ b/crates/resolver/src/analyzer.rs
@@ -1,5 +1,5 @@
-use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use serde::{Deserialize, Serialize, Serializer};
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 pub mod rust;
@@ -17,9 +17,9 @@ pub struct Package {
 //
 #[derive(Serialize, Deserialize)]
 pub struct InitConfig {
-    #[serde(rename = "packages")]
-    packages: HashMap<String, Package>,
-    tags: std::collections::HashMap<String, String>,
+    #[serde(rename = "packages", serialize_with = "inline_btreemap::serialize")]
+    packages: BTreeMap<String, Package>,
+    tags: BTreeMap<String, String>,
 }
 
 pub fn default(root: &PathBuf) -> anyhow::Result<Box<dyn ProjectAnalyzer>> {
@@ -27,4 +27,31 @@ pub fn default(root: &PathBuf) -> anyhow::Result<Box<dyn ProjectAnalyzer>> {
         return Ok(Box::new(rust::RustAnalyzer { root: root.clone() }));
     }
     Err(anyhow::anyhow!("Not found project analyzer"))
+}
+// 自定义模块实现内联表序列化（针对BTreeMap）
+mod inline_btreemap {
+    use super::*;
+    use serde::ser::SerializeMap;
+
+    // 序列化 BTreeMap 为 TOML 内联表
+    pub fn serialize<S>(map: &BTreeMap<String, Package>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut map_serializer = serializer.serialize_map(Some(map.len()))?;
+
+        for (k, v) in map {
+            map_serializer.serialize_entry(k, v)?;
+        }
+
+        map_serializer.end()
+    }
+
+    // 反序列化函数（针对BTreeMap）
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<BTreeMap<String, Package>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        BTreeMap::deserialize(deserializer)
+    }
 }

--- a/crates/resolver/src/analyzer.rs
+++ b/crates/resolver/src/analyzer.rs
@@ -1,0 +1,30 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+pub mod rust;
+
+// 项目分析器
+pub trait ProjectAnalyzer {
+    fn analyze(&self) -> anyhow::Result<InitConfig>;
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Package {
+    pub path: PathBuf,
+}
+
+//
+#[derive(Serialize, Deserialize)]
+pub struct InitConfig {
+    #[serde(rename = "packages")]
+    packages: HashMap<String, Package>,
+    tags: std::collections::HashMap<String, String>,
+}
+
+pub fn default(root: &PathBuf) -> anyhow::Result<Box<dyn ProjectAnalyzer>> {
+    if root.join("Cargo.toml").exists() {
+        return Ok(Box::new(rust::RustAnalyzer { root: root.clone() }));
+    }
+    Err(anyhow::anyhow!("Not found project analyzer"))
+}

--- a/crates/resolver/src/analyzer/rust.rs
+++ b/crates/resolver/src/analyzer/rust.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, path::PathBuf};
+use std::{collections::BTreeMap, path::PathBuf};
 use toml::Table;
 
 use crate::analyzer::{InitConfig, Package, ProjectAnalyzer};
@@ -19,8 +19,8 @@ impl ProjectAnalyzer for RustAnalyzer {
 }
 
 impl RustAnalyzer {
-    fn analyze_package(&self, root: &PathBuf) -> anyhow::Result<HashMap<String, Package>> {
-        let mut res_package = HashMap::new();
+    fn analyze_package(&self, root: &PathBuf) -> anyhow::Result<BTreeMap<String, Package>> {
+        let mut res_package = BTreeMap::new();
 
         let config = root
             .read_dir()?
@@ -77,7 +77,7 @@ impl RustAnalyzer {
         return Ok(res_package);
     }
 
-    fn generate_tag(&self) -> anyhow::Result<std::collections::HashMap<String, String>> {
+    fn generate_tag(&self) -> anyhow::Result<BTreeMap<String, String>> {
         // 获取用户输入
         let mut input = String::new();
         std::io::stdin().read_line(&mut input)?;
@@ -85,7 +85,7 @@ impl RustAnalyzer {
 
         // 根据输入决定是否初始化map
         if input == "y" || input == "1" {
-            Ok(std::collections::HashMap::from_iter([
+            Ok(BTreeMap::from_iter([
                 ("chore".to_string(), "Chore".to_string()),
                 ("feat".to_string(), "New Feature".to_string()),
                 ("fix".to_string(), "Bug Fix".to_string()),
@@ -93,7 +93,7 @@ impl RustAnalyzer {
                 ("refactor".to_string(), "Refactor".to_string()),
             ]))
         } else {
-            Ok(std::collections::HashMap::new())
+            Ok(BTreeMap::new())
         }
     }
 }

--- a/crates/resolver/src/analyzer/rust.rs
+++ b/crates/resolver/src/analyzer/rust.rs
@@ -1,0 +1,99 @@
+use std::{collections::HashMap, path::PathBuf};
+use toml::Table;
+
+use crate::analyzer::{InitConfig, Package, ProjectAnalyzer};
+
+pub struct RustAnalyzer {
+    pub root: PathBuf,
+}
+
+impl ProjectAnalyzer for RustAnalyzer {
+    fn analyze(&self) -> anyhow::Result<InitConfig> {
+        let package = self.analyze_package(&self.root)?;
+        let tags = self.generate_tag()?;
+        Ok(InitConfig {
+            packages: package,
+            tags,
+        })
+    }
+}
+
+impl RustAnalyzer {
+    fn analyze_package(&self, root: &PathBuf) -> anyhow::Result<HashMap<String, Package>> {
+        let mut res_package = HashMap::new();
+
+        let config_path = root
+            .read_dir()?
+            .filter_map(Result::ok)
+            .find(|entry| {
+                entry.path().is_file()
+                    && entry
+                        .file_name()
+                        .to_str()
+                        .map(|name| name.eq_ignore_ascii_case("Cargo.toml"))
+                        .unwrap_or(false)
+            })
+            .map(|entry| entry.path());
+
+        let Some(config_path) = config_path else {
+            log::warn!("Not found Cargo.toml in {}", root.display());
+            return Ok(res_package);
+        };
+
+        let doc = std::fs::read_to_string(config_path)?.parse::<Table>()?;
+
+        if let Some(package) = doc.get("packages").and_then(|value| value.as_table()) {
+            match package["name"].as_str() {
+                Some(name) => {
+                    res_package.insert(name.to_string(), Package { path: root.clone() });
+                }
+                None => {
+                    log::warn!("Not found package name in {}", root.display());
+                    return Ok(res_package);
+                }
+            }
+        }
+
+        let Some(workspace) = doc.get("workspace").and_then(|v| v.as_table()) else {
+            return Ok(res_package);
+        };
+        let Some(members) = workspace.get("members").and_then(|v| v.as_array()) else {
+            return Ok(res_package);
+        };
+
+        members
+            .iter()
+            .filter_map(|map| map.as_str())
+            .flat_map(|pattern| glob::glob(&root.join(pattern).to_string_lossy()).ok())
+            .flatten()
+            .filter_map(Result::ok)
+            .for_each(|path| {
+                log::info!("Found package in {}", path.display());
+                if let Ok(package) = self.analyze_package(&path) {
+                    res_package.extend(package);
+                }
+            });
+
+        return Ok(res_package);
+    }
+
+    fn generate_tag(&self) -> anyhow::Result<std::collections::HashMap<String, String>> {
+        // 获取用户输入
+        let mut input = String::new();
+        std::io::stdin().read_line(&mut input)?;
+        let input = input.trim().to_lowercase();
+
+        // 根据输入决定是否初始化map
+        if input == "y" || input == "1" {
+            Ok(std::collections::HashMap::from_iter([
+                ("chore".to_string(), "Chore".to_string()),
+                ("feat".to_string(), "New Feature".to_string()),
+                ("fix".to_string(), "Bug Fix".to_string()),
+                ("perf".to_string(), "Performance Improvement".to_string()),
+                ("refactor".to_string(), "Refactor".to_string()),
+            ]))
+        } else {
+            Ok(std::collections::HashMap::new())
+        }
+    }
+}

--- a/crates/resolver/src/analyzer/rust.rs
+++ b/crates/resolver/src/analyzer/rust.rs
@@ -22,7 +22,7 @@ impl RustAnalyzer {
     fn analyze_package(&self, root: &PathBuf) -> anyhow::Result<HashMap<String, Package>> {
         let mut res_package = HashMap::new();
 
-        let config_path = root
+        let config = root
             .read_dir()?
             .filter_map(Result::ok)
             .find(|entry| {
@@ -35,14 +35,14 @@ impl RustAnalyzer {
             })
             .map(|entry| entry.path());
 
-        let Some(config_path) = config_path else {
+        let Some(config_path) = config else {
             log::warn!("Not found Cargo.toml in {}", root.display());
             return Ok(res_package);
         };
 
         let doc = std::fs::read_to_string(config_path)?.parse::<Table>()?;
 
-        if let Some(package) = doc.get("packages").and_then(|value| value.as_table()) {
+        if let Some(package) = doc.get("package").and_then(|value| value.as_table()) {
             match package["name"].as_str() {
                 Some(name) => {
                     res_package.insert(name.to_string(), Package { path: root.clone() });

--- a/crates/resolver/src/lib.rs
+++ b/crates/resolver/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod analyzer;
 pub mod changeset;
 pub mod config;
 pub mod error;

--- a/crates/resolver/src/resolver/rust.rs
+++ b/crates/resolver/src/resolver/rust.rs
@@ -1,9 +1,12 @@
+use std::{collections::BTreeMap, path::PathBuf};
+
 use serde::{Deserialize, Serialize};
+use toml::Table;
 
 use crate::{
     changeset::BumpLevel,
     config::{Config, PackageConfig},
-    resolver::{ResolvedPackage, Resolver},
+    resolver::{ChangesConfig, ConfigPackage, ResolvedPackage, Resolver},
     utils,
 };
 
@@ -61,5 +64,94 @@ impl Resolver for RustResolver<'_, '_> {
             toml_doc.to_string(),
         )?;
         Ok(())
+    }
+
+    fn analyze_project(&mut self, root: &PathBuf) -> anyhow::Result<ChangesConfig> {
+        let package = self.analyze_package(root)?;
+        let tags = self.generate_tag()?;
+        Ok(ChangesConfig {
+            packages: package,
+            tags,
+        })
+    }
+}
+
+impl RustResolver<'_, '_> {
+    fn analyze_package(&self, root: &PathBuf) -> anyhow::Result<BTreeMap<String, ConfigPackage>> {
+        let mut res_package = BTreeMap::new();
+
+        let config = root
+            .read_dir()?
+            .filter_map(Result::ok)
+            .find(|entry| {
+                entry.path().is_file()
+                    && entry
+                        .file_name()
+                        .to_str()
+                        .map(|name| name.eq_ignore_ascii_case("Cargo.toml"))
+                        .unwrap_or(false)
+            })
+            .map(|entry| entry.path());
+
+        let Some(config_path) = config else {
+            log::warn!("Not found Cargo.toml in {}", root.display());
+            return Ok(res_package);
+        };
+
+        let doc = std::fs::read_to_string(config_path)?.parse::<Table>()?;
+
+        if let Some(package) = doc.get("package").and_then(|value| value.as_table()) {
+            match package["name"].as_str() {
+                Some(name) => {
+                    res_package.insert(name.to_string(), ConfigPackage { path: root.clone() });
+                }
+                None => {
+                    log::warn!("Not found package name in {}", root.display());
+                    return Ok(res_package);
+                }
+            }
+        }
+
+        let Some(workspace) = doc.get("workspace").and_then(|v| v.as_table()) else {
+            return Ok(res_package);
+        };
+        let Some(members) = workspace.get("members").and_then(|v| v.as_array()) else {
+            return Ok(res_package);
+        };
+
+        members
+            .iter()
+            .filter_map(|map| map.as_str())
+            .flat_map(|pattern| glob::glob(&root.join(pattern).to_string_lossy()).ok())
+            .flatten()
+            .filter_map(Result::ok)
+            .for_each(|path| {
+                log::info!("Found package in {}", path.display());
+                if let Ok(package) = self.analyze_package(&path) {
+                    res_package.extend(package);
+                }
+            });
+
+        return Ok(res_package);
+    }
+
+    fn generate_tag(&self) -> anyhow::Result<BTreeMap<String, String>> {
+        // 获取用户输入
+        let mut input = String::new();
+        std::io::stdin().read_line(&mut input)?;
+        let input = input.trim().to_lowercase();
+
+        // 根据输入决定是否初始化map
+        if input == "y" || input == "1" {
+            Ok(BTreeMap::from_iter([
+                ("chore".to_string(), "Chore".to_string()),
+                ("feat".to_string(), "New Feature".to_string()),
+                ("fix".to_string(), "Bug Fix".to_string()),
+                ("perf".to_string(), "Performance Improvement".to_string()),
+                ("refactor".to_string(), "Refactor".to_string()),
+            ]))
+        } else {
+            Ok(BTreeMap::new())
+        }
     }
 }

--- a/crates/resolver/src/resolver/toml_serializer.rs
+++ b/crates/resolver/src/resolver/toml_serializer.rs
@@ -1,0 +1,19 @@
+use serde::Serializer;
+use serde::ser::SerializeMap;
+use std::collections::BTreeMap;
+
+use crate::resolver::ConfigPackage;
+
+// 序列化 BTreeMap 为 TOML 内联表
+pub fn serialize<S>(map: &BTreeMap<String, ConfigPackage>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let mut map_serializer = serializer.serialize_map(Some(map.len()))?;
+
+    for (k, v) in map {
+        map_serializer.serialize_entry(k, v)?;
+    }
+
+    map_serializer.end()
+}

--- a/crates/semanifold/Cargo.toml
+++ b/crates/semanifold/Cargo.toml
@@ -8,6 +8,7 @@ anyhow = "1.0.99"
 clap = { version = "4.5.45", features = ["derive"] }
 colored = "3.0.0"
 fern = "0.7.1"
+glob = "0.3.3"
 inquire = "0.7.5"
 log = "0.4.27"
 saphyr = "0.0.6"

--- a/crates/semanifold/src/cli/init.rs
+++ b/crates/semanifold/src/cli/init.rs
@@ -6,32 +6,58 @@ use toml_edit::{DocumentMut, Table, value};
 
 fn find_rust_package(root: &PathBuf) -> anyhow::Result<Table> {
     let mut packages = Table::new();
-    let config_path = root.join("Cargo.toml");
 
-    let config = std::fs::read_to_string(config_path)
-        .map_err(|_| anyhow::Error::msg("Cargo.toml not found in root"))?;
+    // Case-insensitive file lookup
+    let config_path = root
+        .read_dir()?
+        .filter_map(Result::ok)
+        .find(|entry| {
+            entry.path().is_file()
+                && entry
+                    .file_name()
+                    .to_str()
+                    .map(|name| name.eq_ignore_ascii_case("Cargo.toml"))
+                    .unwrap_or(false)
+        })
+        .map(|entry| entry.path());
 
-    let doc = config.parse::<DocumentMut>()?;
+    let Some(config_path) = config_path else {
+        log::warn!("在{}目录未找到Cargo.toml文件", root.display());
+        return Ok(packages);
+    };
+
+    let doc = std::fs::read_to_string(config_path)?.parse::<DocumentMut>()?;
 
     if let Some(pkg) = doc.get("package").and_then(|v| v.as_table()) {
-        packages[pkg["name"].as_str().unwrap()]["path"] = value(root.to_str().unwrap());
-    } else if let Some(workspace) = doc.get("workspace").and_then(|v| v.as_table()) {
-        if let Some(members) = workspace.get("members").and_then(|v| v.as_array()) {
-            for member in members {
-                if let Some(pattern) = member.as_str() {
-                    let paths = glob::glob(&root.join(pattern).to_string_lossy())?;
-                    for entry in paths {
-                        let member_path = entry?;
-                        if member_path.join("Cargo.toml").exists() {
-                            log::info!("Found workspace member: {}", member_path.display());
-                            let pkg = find_rust_package(&member_path)?;
-                            packages.extend(pkg);
-                        }
-                    }
-                }
+        match pkg["name"].as_str() {
+            Some(name) => packages[name]["path"] = value(root.to_str().unwrap()),
+            None => {
+                log::warn!("{}cargo缺少name字段", root.display());
+                return Ok(packages);
             }
         }
+        return Ok(packages);
     }
+
+    let Some(workspace) = doc.get("workspace").and_then(|v| v.as_table()) else {
+        return Ok(packages);
+    };
+    let Some(members) = workspace.get("members").and_then(|v| v.as_array()) else {
+        return Ok(packages);
+    };
+
+    members
+        .iter()
+        .filter_map(|m| m.as_str())
+        .flat_map(|pattern| glob::glob(&root.join(pattern).to_string_lossy()).ok())
+        .flatten()
+        .filter_map(Result::ok)
+        .for_each(|entry| {
+            log::info!("Found workspace member: {}", entry.display());
+            if let Ok(pkg) = find_rust_package(&entry) {
+                packages.extend(pkg);
+            }
+        });
 
     Ok(packages)
 }

--- a/crates/semanifold/src/cli/init.rs
+++ b/crates/semanifold/src/cli/init.rs
@@ -2,65 +2,7 @@ use std::{fmt::Debug, path::PathBuf};
 
 use clap::{Args, arg};
 use log::info;
-use toml_edit::{DocumentMut, Table, value};
-
-fn find_rust_package(root: &PathBuf) -> anyhow::Result<Table> {
-    let mut packages = Table::new();
-
-    // Case-insensitive file lookup
-    let config_path = root
-        .read_dir()?
-        .filter_map(Result::ok)
-        .find(|entry| {
-            entry.path().is_file()
-                && entry
-                    .file_name()
-                    .to_str()
-                    .map(|name| name.eq_ignore_ascii_case("Cargo.toml"))
-                    .unwrap_or(false)
-        })
-        .map(|entry| entry.path());
-
-    let Some(config_path) = config_path else {
-        log::warn!("在{}目录未找到Cargo.toml文件", root.display());
-        return Ok(packages);
-    };
-
-    let doc = std::fs::read_to_string(config_path)?.parse::<DocumentMut>()?;
-
-    if let Some(pkg) = doc.get("package").and_then(|v| v.as_table()) {
-        match pkg["name"].as_str() {
-            Some(name) => packages[name]["path"] = value(root.to_str().unwrap()),
-            None => {
-                log::warn!("{}cargo缺少name字段", root.display());
-                return Ok(packages);
-            }
-        }
-        return Ok(packages);
-    }
-
-    let Some(workspace) = doc.get("workspace").and_then(|v| v.as_table()) else {
-        return Ok(packages);
-    };
-    let Some(members) = workspace.get("members").and_then(|v| v.as_array()) else {
-        return Ok(packages);
-    };
-
-    members
-        .iter()
-        .filter_map(|m| m.as_str())
-        .flat_map(|pattern| glob::glob(&root.join(pattern).to_string_lossy()).ok())
-        .flatten()
-        .filter_map(Result::ok)
-        .for_each(|entry| {
-            log::info!("Found workspace member: {}", entry.display());
-            if let Ok(pkg) = find_rust_package(&entry) {
-                packages.extend(pkg);
-            }
-        });
-
-    Ok(packages)
-}
+use semanifold_resolver::analyzer;
 
 #[derive(Debug, Args)]
 pub(crate) struct Init {
@@ -71,24 +13,20 @@ pub(crate) struct Init {
 pub(crate) fn run(init: &Init) -> anyhow::Result<()> {
     std::fs::create_dir_all(&init.root)?;
 
-    // init config.toml file
     let config_path = init.root.join("config.toml");
 
-    let mut doc = DocumentMut::new();
-    //init packages
+    let parent_path = init.root.parent().unwrap().to_path_buf();
+    //init config
+    let analyzer = analyzer::default(&parent_path)?;
 
-    let packages = find_rust_package(&init.root.parent().unwrap().to_path_buf())?;
-    doc["packages"] = toml_edit::Item::Table(packages);
-    // init tags
-    let mut tags = Table::new();
-    tags["chore"] = value("Chore");
-    tags["feat"] = value("New Feature");
-    tags["fix"] = value("Bug Fix");
-    tags["perf"] = value("Performance Improvement");
-    tags["refactor"] = value("Refactor");
-    doc["tags"] = toml_edit::Item::Table(tags);
+    let config = analyzer.analyze()?;
+
+    // 写入config.toml文件
+    let config_doc = toml::to_string_pretty(&config)?;
+
     // write config.toml file
-    std::fs::write(config_path, doc.to_string())?;
+    std::fs::write(config_path, config_doc)?;
+
     info!("Initialized semanifold in {}", init.root.display());
     Ok(())
 }


### PR DESCRIPTION
在resolver中声明analysis函数，实现rust 项目自动解析 ，通过defualt函数 检测返回什么样的analyzer。

Declare the analysis module in the resolver and implement the rust projects analyzer.

The default function to detect what kind of project .Currently, it only returns Rust analyzer or panic.

先别合，还没写完